### PR TITLE
Upload 10 files at a time, plus other minor changes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,14 +1,13 @@
 {
+  "boss": true,
   "curly": true,
   "eqeqeq": true,
+  "eqnull": true,
   "immed": true,
-  "latedef": true,
+  "latedef" : false,
   "newcap": true,
   "noarg": true,
-  "sub": true,
-  "undef": true,
-  "boss": true,
-  "eqnull": true,
   "node": true,
-  "latedef" : false
+  "sub": true,
+  "undef": true
 }

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ grunt-azureblob is a multi task that implicity iterates over all of its name sub
   containerDelete: false, // deletes container if it exists
   containerOptions: {publicAccessLevel: "blob", timeoutIntervalInMs: 10000}, // container options
   copySimulation: false, // do everything but physically touch storage blob when true
-  destPrefix: '', // prefix to use for blob name e.g. 'v0.0.1/'
-  maskBaseDir: '',  // mask off directory portion to map files to root in storage container
   metadata: {cacheControl: 'public, max-age=31556926'}, // file metadata properties
   gzip: false, // gzip files (when true: only js / css will be gzip'd)
   maxNumberOfConcurrentUploads: 10 // Maximum number of concurrent uploads
@@ -55,21 +53,28 @@ module.exports = function(grunt) {
         containerDelete: false,
         metadata: {cacheControl: 'public, max-age=31556926'}, // max-age 1 year for all entries
         gzip: true,
-        copySimulation: true,  // set true: dry-run for what copy would look like in output
-        destPrefix: '<%= pkg.version %>/'
+        copySimulation: true  // set true: dry-run for what copy would look like in output
       },
       css :{
-        options: {
-          maskBaseDir: '../web/Content/'  // strip off this prefix from files
-        },
-        src: ['../web/Content/**/*','!../web/Content/themes/**/*'] // copy all files from Content (exclude themes dir)
+        files: [{
+          expand: true,
+          cwd: '../web/Content',
+          filter: 'isFile',
+          dest: '<%= pkg.version %>/',
+          src: ['**/*', '!themes/**/*'] // copy all files from Content (exclude themes dir)
+        }]
       },
       js :{
         options: {
-          containerDelete: false,
-          maskBaseDir: '../web/scripts/'
+          containerDelete: false
         },
-        src: ['../web/scripts/vendor*.js']
+        files: [{
+          expand: true,
+          cwd: '../web/scripts',
+          filter: 'isFile',
+          dest: '<%= pkg.version %>/',
+          src: ['vendor*.js']
+        }]
       }
     }
   });

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ grunt.loadNpmTasks('grunt-azureblob');
 ```
 # Environment Requirment
 + Azure SDK provides Node.js package for access to Azure Table Storage.  By default, this library uses the following environment variables for authentication (set as required as global, user, or with a task).  I've had great success with grunt-env to manage the these settings as a task (sample usage shown below).  _These environment variables must be set to your appropriate values!_
-  + AZURE_STORAGE_ACCOUNT 
-  + AZURE_STORAGE_ACCESS_KEY   
+  + AZURE_STORAGE_ACCOUNT
+  + AZURE_STORAGE_ACCESS_KEY
 
 
 ## AzureBlob Options and default values
@@ -30,11 +30,12 @@ grunt-azureblob is a multi task that implicity iterates over all of its name sub
   destPrefix: '', // prefix to use for blob name e.g. 'v0.0.1/'
   maskBaseDir: '',  // mask off directory portion to map files to root in storage container
   metadata: {cacheControl: 'public, max-age=31556926'}, // file metadata properties
-  gzip: false // gzip files (when true: only js / css will be gzip'd)
+  gzip: false, // gzip files (when true: only js / css will be gzip'd)
+  maxNumberOfConcurrentUploads: 10 // Maximum number of concurrent uploads
 };
 ````
 
-## Example gruntfile.js 
+## Example gruntfile.js
 ```javascript
 module.exports = function(grunt) {
   grunt.initConfig({
@@ -77,8 +78,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-env'); // https://npmjs.org/package/grunt-env
   grunt.loadNpmTasks('grunt-azureblob');
   // Default task(s).
-  grunt.registerTask('blob', ['env:configCDN', 'azureblob']); 
-  
+  grunt.registerTask('blob', ['env:configCDN', 'azureblob']);
+
   grunt.event.on('qunit.spawn', function (url) {
   grunt.log.ok("Running test: " + url);
 });
@@ -88,7 +89,7 @@ grunt.event.on('qunit.moduleStart', function (name) {
 ```
 ## Sample console run (from sample/build/gruntfile.js)
 ```console
-c:\sample>grunt blob  
+c:\sample>grunt blob
 
 Running "env:configCDN" (env) task
 

--- a/tasks/azureblob.js
+++ b/tasks/azureblob.js
@@ -10,7 +10,6 @@ module.exports = function(grunt) {
       fs = require('fs'),
       tmp = require('tmp');
 
-
   grunt.registerMultiTask('azureblob', 'Copy html assets to azure blob/cdn storage', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
@@ -22,8 +21,9 @@ module.exports = function(grunt) {
         copySimulation: false,
         destPrefix: '', // detination path prefix to use for blob name e.g. 'v0.0.1/'
         maskBaseDir: '',
-        gzip: false // gzip files
-      }), 
+        gzip: false, // gzip files
+        maxNumberOfConcurrentUploads: 10 // Maximum number of concurrent uploads
+      }),
       blobService = azure.createBlobService(),
       done = this.async(),
       self = this;
@@ -51,29 +51,28 @@ module.exports = function(grunt) {
       var deferred = Q.defer(),
         files = self.filesSrc.filter(fileExists); // filesSrc can include dir's, not just files
 
-        grunt.verbose.writeln(util.format('\tprocess (%s) files',files.length));
+      grunt.verbose.writeln(util.format('\tprocess (%s) files', files.length));
 
-        // Iterate over all specified file groups.
-        grunt.util.async.forEachSeries(files, copyFile, function(err){
-          if (err) {
-            deferred.reject(err);
-          }
-          deferred.resolve(files.length);
-        });
+      // Iterate over all specified file groups, <options.maxNumberOfConcurrentUploads> files at a time
+      grunt.util.async.forEachLimit(files, options.maxNumberOfConcurrentUploads, copyFile, function(err){
+        if (err) {
+          deferred.reject(err);
+        }
+        deferred.resolve(files.length);
+      });
 
       return deferred.promise;
-    }   
+    }
 
     // When optioned, delete blob container
     // returns q promise
     function deleteContainer() {
       var deferred = Q.defer();
-     
+
       if (options.containerDelete && !options.copySimulation) {
-       
         grunt.log.writeln(util.format('%s - deleting container [%s] ...', self.nameArgs, options.containerName));
         blobService.deleteContainer(options.containerName, {timeoutIntervalInMs:25000}, function(err){
-            /* // ignore errors for now - just move on 
+            /* // ignore errors for now - just move on
             if (err) {
               grunt.log.writeln(err);
               deferred.reject(err);
@@ -97,20 +96,20 @@ module.exports = function(grunt) {
           waitMs = 100,
           maxTry = 10;
 
-      options.containerOptions.timeoutIntervalInMs = options.containerOptions.timeoutIntervalInMs || 15000; // 10sec
+      options.containerOptions.timeoutIntervalInMs = options.containerOptions.timeoutIntervalInMs || 15000; // 15sec
       grunt.log.write(util.format('%s - Create blob containter [%s] ...', self.nameArgs, options.containerName));
-      
+
       if(options.copySimulation){
         completed = true;
         tryCallback();
       } else {
         grunt.util.async.whilst(continueAttempts, tryCreate, tryCallback);
       }
-      
+
       return deferred.promise;
 
       function continueAttempts() {
-        return  ((count < maxTry) && !completed); // sync truth test before each execution of fn
+        return ((count < maxTry) && !completed); // sync truth test before each execution of fn
       }
       function tryCreate(callback) {
         count++;
@@ -141,11 +140,10 @@ module.exports = function(grunt) {
             deferred.reject(err);
           }
       }
-    } 
+    }
 
-    // Iterator called from grunt.util.async.forEachSeries - for each source file in task
+    // Iterator called from grunt.util.async.forEachLimit - for each source file in task
     function copyFile(source, callback) {
-
       var destination = source,  // set default destination same as source
           meta = options.metadata,
           srcFile = path.basename(source),
@@ -153,7 +151,7 @@ module.exports = function(grunt) {
           fileExt = path.extname(source),
           fnCopyToBlob;
 
-      // only create gzip copies for css and js files 
+      // only create gzip copies for css and js files
       if (fileExt !== '.js' && fileExt !== '.css') {
           gzip = false;
       }
@@ -162,9 +160,11 @@ module.exports = function(grunt) {
       if (options.maskBaseDir) {
         destination = source.replace(options.maskBaseDir,'');
       }
+
       if (options.destPrefix && options.destPrefix.length > 0 && options.destPrefix.substr(-1) !== '/') {
         options.destPrefix += '/';
       }
+
       if (options.destPrefix) {
         destination = options.destPrefix + destination;
       }
@@ -174,18 +174,22 @@ module.exports = function(grunt) {
       meta.contentTypeHeader =  mime.lookup(source);
       meta.contentEncoding =  gzip ? 'gzip': null;
 
-      grunt.log.write(util.format('\tCopy %s => %s/%s ', srcFile, options.containerName, destination));
+      var logMessage = util.format('\tCopy %s => %s/%s ', srcFile, options.containerName, destination);
 
       if(options.copySimulation){
-          grunt.log.ok('skip copy ok');
-          callback();
-          return;
+        grunt.log.write(logMessage);
+        grunt.log.ok('skip copy ok');
+        callback();
+        return;
       }
 
       fnCopyToBlob = gzip ? compressFileToBlobStorage : copyFileToBlobStorage; // use correct fn to pre-compress
 
       Q.when(fnCopyToBlob(options.containerName, destination, source, meta))
         .then(function(){
+            grunt.log.write(logMessage); // We have to save logging about the file upload until here since
+                                         // we are iterating over many files concurrently. Otherwise the
+                                         // log output becomes interleaved and therefore unintelligible.
             grunt.log.ok();
             callback();
         }).done();
@@ -197,19 +201,19 @@ module.exports = function(grunt) {
                 return copyFileToBlobStorage(containerName, destFileName, tmpFile, metadata)
                         .finally(function(){
                           fs.unlinkSync(tmpFile);
-                          }); 
-            });
+                        });
+              });
     }
 
     function copyFileToBlobStorage(containerName, destFileName, sourceFile, metadata) {
       var deferred = Q.defer();
       blobService.createBlockBlobFromFile(containerName, destFileName, sourceFile, metadata, function(err) {
-          if (err) {
-            grunt.log.error(err);
-            deferred.reject(err);
-          } else {
-            deferred.resolve();
-          }
+        if (err) {
+          grunt.log.error(err);
+          deferred.reject(err);
+        } else {
+          deferred.resolve();
+        }
       });
       return deferred.promise;
     }
@@ -220,7 +224,7 @@ module.exports = function(grunt) {
         fileExt = path.extname(source),
         inp,
         out;
-          
+
       gzip.on('error', function(err) {
         grunt.log.error(err);
         grunt.fail.warn('Gziping failed.');
@@ -233,10 +237,10 @@ module.exports = function(grunt) {
         }
 
         inp = fs.createReadStream(source);
-                
+
         out = fs.createWriteStream(tempFile);
         out.on('close', function() {
-          deferred.resolve(tempFile); // once file closes, file is writen and avail.
+          deferred.resolve(tempFile); // once file closes, file is written and available.
         });
         inp.pipe(gzip).pipe(out);
         //inp.pipe(out); // test to just copy file
@@ -245,11 +249,8 @@ module.exports = function(grunt) {
     }
 
     function fileExists (dest) {
-      if (fs.statSync(dest).isFile() && fs.existsSync(dest) ) {
-          return true;
-      }
-      return false;
+      return fs.statSync(dest).isFile() && fs.existsSync(dest);
     }
-    
+
   });
 };


### PR DESCRIPTION
- My editor stripped trailing spaces. Please forgive me :)
- There were also some minor spacing/indentation inconsistencies I
  fixed.
- Changed behavior to upload 10 files at a time instead of uploading
  each file one at a time.  This _drastically_ improves performance of
  the task.
- Added maxNumberOfConcurrentUploads option which defaults to 10 to
  control the above behavior.
- There were two 'latedef' entries in .jshintrc file. In addition to
  removing the redundant one, I sorted them to make such a future
  mistake less likely.
