### PR TITLE
Check if contentType and contentTypeHeader is already set

### DIFF
--- a/tasks/azureblob.js
+++ b/tasks/azureblob.js
@@ -172,8 +172,12 @@ module.exports = function(grunt) {
         fnCopyToBlob;
 
       // configure proper azure metadata for specific file
-      meta.contentType = mime.lookup(source);
-      meta.contentTypeHeader = mime.lookup(source);
+      if(meta.contentType === undefined) {
+        meta.contentType = mime.lookup(source);
+      }
+      if(meta.contentTypeHeader === undefined) {
+        meta.contentTypeHeader = mime.lookup(source);
+      }
       meta.contentEncoding = gzip ? 'gzip' : null;
 
       logMessage = util.format('\tCopy %s => %s/%s - %s ', srcFile, options.containerName, destination, meta.contentType);


### PR DESCRIPTION
Hi,

We have used your grunt task for uploading to Azure blob storage, and it worked great. 
However when we tried to set content-type via metadata (to add a charset), it didnt work.

This is a fix for that, to just check if the meta is already set and avoid overwriting it with the automatic lookup.
Maybe there is a better solution to add charset to the Content-Type header that you know of, but otherwise i hope you can accept this fix so that we can continue to use your version.
