### PR TITLE
Use serviceOptions option in azure.createBlobService

### DIFF
--- a/tasks/azureblob.js
+++ b/tasks/azureblob.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
       gzip: false, // gzip files
       maxNumberOfConcurrentUploads: 10 // Maximum number of concurrent uploads
     }),
-      blobService = azure.createBlobService(),
+      blobService = azure.createBlobService.apply(azure, options.serviceOptions),
       done = this.async(),
       self = this;
 


### PR DESCRIPTION
Allow to use serviceOptions option to set storage account connection strings or credentials.

You can find the documentation of the azure.createBlobService method at: http://dl.windowsazure.com/nodedocs/global.html#createBlobService
